### PR TITLE
add filesystem=home

### DIFF
--- a/com.github.buddhi1980.mandelbulber2.yaml
+++ b/com.github.buddhi1980.mandelbulber2.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
+  - --filesystem=home
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
Hello,

I somehow could not save the rendered image.

1.Open mandelbulber2
2. Click render on the top right.
3. Select Image and save image on the top menu.
4. No image is actually exported. Even saving in .mandelbulber or mandelbulber does not work.

Could this be because Mandelbulber2 does not work properly with portal? So I add filesystem=home which fix the issue https://github.com/flathub/com.github.buddhi1980.mandelbulber2/issues/1.