### PR TITLE
Use lzo module from runtime and more

### DIFF
--- a/com.github.buddhi1980.mandelbulber2.yaml
+++ b/com.github.buddhi1980.mandelbulber2.yaml
@@ -92,20 +92,6 @@ modules:
           type: git
           tag-pattern: ^(v[\d.]+)$
 
-  - name: lzo
-    config-opts:
-      - --enable-shared
-      - --disable-static
-    sources:
-      - type: archive
-        url: http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
-        sha256: c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
-        x-checker-data:
-          type: anitya
-          project-id: 1868
-          stable-only: true
-          url-template: http://www.oberhumer.com/opensource/lzo/download/lzo-$version.tar.gz
-
   - name: Mandelbulber2
     buildsystem: qmake
     subdir: mandelbulber2/qmake

--- a/com.github.buddhi1980.mandelbulber2.yaml
+++ b/com.github.buddhi1980.mandelbulber2.yaml
@@ -15,7 +15,6 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
-  - /share/doc
   - /share/man
   - /share/pkgconfig
   - /share/cmake

--- a/com.github.buddhi1980.mandelbulber2.yaml
+++ b/com.github.buddhi1980.mandelbulber2.yaml
@@ -38,21 +38,6 @@ modules:
           stable-only: true
           url-template: https://ftp.gnu.org/gnu/gsl/gsl-$version.tar.gz
 
-  # Needed to build opencl-headers. Will be removed at the end.
-  - name: ruby
-    config-opts:
-      - --enable-shared
-    build-options:
-      cflags: -std=c17
-    cleanup:
-      - '*'
-    post-install:
-      - cp /usr/lib/${FLATPAK_ARCH}-linux-gnu/libyaml-0.so* ${FLATPAK_DEST}/lib
-    sources:
-      - type: archive
-        url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz
-        sha256: 61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e
-
   - name: OpenCL-Headers
     buildsystem: cmake-ninja
     sources:


### PR DESCRIPTION
### Use the lzo module from the runtime

Freedesktop runtime 25.08 already provides this module

See: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/lzo.bst?ref_type=heads

### Use the Ruby module from the runtime

Freedesktop runtime 25.08 already provides this module

See: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/ruby.bst?ref_type=heads

Fixes: https://github.com/flathub/com.github.buddhi1980.mandelbulber2/issues/55

### Keep /share/doc files

Users can access these files via Help > User Manual (Ctrl + H)
